### PR TITLE
fix: Correct rel-34 branches

### DIFF
--- a/edk2-nvidia/Jetson/NVIDIAJetsonManifest.xml
+++ b/edk2-nvidia/Jetson/NVIDIAJetsonManifest.xml
@@ -46,8 +46,8 @@
 
   <CombinationList>
     <Combination name="rel-34" description="The main branch">
-      <Source localRoot="edk2" remote="Edk2Repo" branch="rel-34" enableSubmodule="true" />
-      <Source localRoot="edk2-platforms" remote="Edk2PlatformsRepo" branch="rel-34" sparseCheckout="true" />
+      <Source localRoot="edk2" remote="Edk2Repo" branch="rel-34-edk2-stable202111" enableSubmodule="true" />
+      <Source localRoot="edk2-platforms" remote="Edk2PlatformsRepo" branch="rel-34-upstream-20210901" sparseCheckout="true" />
       <Source localRoot="edk2-nvidia" remote="Edk2NvidiaRepo" branch="rel-34"/>
       <Source localRoot="edk2-nvidia-non-osi" remote="Edk2NvidiaNonOsiRepo" branch="rel-34"/>
     </Combination>


### PR DESCRIPTION
The manifest was mistakenly pointing to the rel-34 branches of edk2 and
edk2-platforms.  Instead, it should be using rel-34-edk2-stable202111
and rel-34-upstream-20210901, respectively, which represent the upstream
branch point.