### PR TITLE
chore: Update manifest for uefi-202403.0

### DIFF
--- a/edk2-nvidia/Platform/NVIDIAPlatformsManifest.xml
+++ b/edk2-nvidia/Platform/NVIDIAPlatformsManifest.xml
@@ -405,6 +405,26 @@
       <Source localRoot="edk2-nvidia-server-gpu-sdk/open-gpu-kernel-modules" remote="OpenRmRepo" tag="525.78.01"/>
     </Combination>
 
+    <!-- uefi-202403 -->
+    <Combination name="uefi-202403.0" description="The uefi-202403.0 pre-release">
+      <Source localRoot="edk2" remote="Edk2Repo" tag="uefi-202403.0" enableSubmodule="true" />
+      <Source localRoot="edk2-non-osi" remote="Edk2NonOsiRepo" tag="uefi-202403.0"/>
+      <Source localRoot="edk2-platforms" remote="Edk2PlatformsRepo" tag="uefi-202403.0" sparseCheckout="true" />
+      <Source localRoot="edk2-redfish-client" remote="Edk2RedfishClientRepo" tag="uefi-202403.0"/>
+      <Source localRoot="edk2-nvidia" remote="Edk2NvidiaRepo" tag="uefi-202403.0"/>
+      <Source localRoot="edk2-nvidia-non-osi" remote="Edk2NvidiaNonOsiRepo" tag="uefi-202403.0"/>
+      <Source localRoot="edk2-nvidia-server-gpu-sdk/open-gpu-kernel-modules" remote="OpenRmRepo" tag="525.78.01"/>
+    </Combination>
+    <Combination name="uefi-202403.0-updates" description="The uefi-202403.0 release, plus updates">
+      <Source localRoot="edk2" remote="Edk2Repo" branch="uefi-202403.0-updates" enableSubmodule="true" />
+      <Source localRoot="edk2-non-osi" remote="Edk2NonOsiRepo" branch="uefi-202403.0-updates"/>
+      <Source localRoot="edk2-platforms" remote="Edk2PlatformsRepo" branch="uefi-202403.0-updates" sparseCheckout="true" />
+      <Source localRoot="edk2-redfish-client" remote="Edk2RedfishClientRepo" branch="uefi-202403.0-updates"/>
+      <Source localRoot="edk2-nvidia" remote="Edk2NvidiaRepo" branch="uefi-202403.0-updates"/>
+      <Source localRoot="edk2-nvidia-non-osi" remote="Edk2NvidiaNonOsiRepo" branch="uefi-202403.0-updates"/>
+      <Source localRoot="edk2-nvidia-server-gpu-sdk/open-gpu-kernel-modules" remote="OpenRmRepo" tag="525.78.01"/>
+    </Combination>
+
   </CombinationList>
 
   <DscList>


### PR DESCRIPTION
The uefi-202403.0 pre-release is based on the uefi-202402.0 pre-release.