### PR TITLE
chore: Update manifest for uefi-202210.5 (r35.6.0)

### DIFF
--- a/edk2-nvidia/Platform/NVIDIAPlatformsManifest.xml
+++ b/edk2-nvidia/Platform/NVIDIAPlatformsManifest.xml
@@ -151,6 +151,20 @@
       <Source localRoot="edk2-nvidia" remote="Edk2NvidiaRepo" tag="r35.5.0-updates"/>
       <Source localRoot="edk2-nvidia-non-osi" remote="Edk2NvidiaNonOsiRepo" tag="r35.5.0-updates"/>
     </Combination>
+    <Combination name="r35.6.0" description="The r35.6.0 release">
+      <Source localRoot="edk2" remote="Edk2Repo" tag="r35.6.0-edk2-stable202208" enableSubmodule="true" />
+      <Source localRoot="edk2-non-osi" remote="Edk2NonOsiRepo" tag="r35.6.0-upstream-20220830"/>
+      <Source localRoot="edk2-platforms" remote="Edk2PlatformsRepo" tag="r35.6.0-upstream-20220830" sparseCheckout="true" />
+      <Source localRoot="edk2-nvidia" remote="Edk2NvidiaRepo" tag="r35.6.0"/>
+      <Source localRoot="edk2-nvidia-non-osi" remote="Edk2NvidiaNonOsiRepo" tag="r35.6.0"/>
+    </Combination>
+    <Combination name="r35.6.0-updates" description="The r35.6.0 release, plus updates">
+      <Source localRoot="edk2" remote="Edk2Repo" tag="r35.6.0-edk2-stable202208-updates" enableSubmodule="true" />
+      <Source localRoot="edk2-non-osi" remote="Edk2NonOsiRepo" tag="r35.6.0-upstream-20220830"/>
+      <Source localRoot="edk2-platforms" remote="Edk2PlatformsRepo" tag="r35.6.0-upstream-20220830-updates" sparseCheckout="true" />
+      <Source localRoot="edk2-nvidia" remote="Edk2NvidiaRepo" tag="r35.6.0-updates"/>
+      <Source localRoot="edk2-nvidia-non-osi" remote="Edk2NvidiaNonOsiRepo" tag="r35.6.0-updates"/>
+    </Combination>
 
     <!-- rel-36 -->
     <Combination name="r36.2" description="The r36.2 developer preview">
@@ -207,6 +221,13 @@
       <Source localRoot="edk2-platforms" remote="Edk2PlatformsRepo" tag="uefi-202210.4" sparseCheckout="true" />
       <Source localRoot="edk2-nvidia" remote="Edk2NvidiaRepo" tag="uefi-202210.4"/>
       <Source localRoot="edk2-nvidia-non-osi" remote="Edk2NvidiaNonOsiRepo" tag="uefi-202210.4"/>
+    </Combination>
+    <Combination name="uefi-202210.5" description="The uefi-202210.5 release">
+      <Source localRoot="edk2" remote="Edk2Repo" tag="uefi-202210.5" enableSubmodule="true" />
+      <Source localRoot="edk2-non-osi" remote="Edk2NonOsiRepo" tag="uefi-202210.5"/>
+      <Source localRoot="edk2-platforms" remote="Edk2PlatformsRepo" tag="uefi-202210.5" sparseCheckout="true" />
+      <Source localRoot="edk2-nvidia" remote="Edk2NvidiaRepo" tag="uefi-202210.5"/>
+      <Source localRoot="edk2-nvidia-non-osi" remote="Edk2NvidiaNonOsiRepo" tag="uefi-202210.5"/>
     </Combination>
 
     <!-- uefi-202305, stable202305 -->


### PR DESCRIPTION
The uefi-202210.5 release is based on the uefi-202210.4 release.  This UEFI release is part of the Jetson Linux 35.6.0 release.