### PR TITLE
fix: Redirect to new subhook URL

### DIFF
--- a/edk2-nvidia/Platform/NVIDIAPlatformsManifest.xml
+++ b/edk2-nvidia/Platform/NVIDIAPlatformsManifest.xml
@@ -46,6 +46,7 @@
   </CommitTemplates>
 
   <SubmoduleAlternateRemotes>
+    <SubmoduleAlternateRemote remote="Edk2Repo" originalUrl="https://github.com/Zeex/subhook.git">https://github.com/tianocore/edk2-subhook.git</SubmoduleAlternateRemote>
   </SubmoduleAlternateRemotes>
 
   <CombinationList>


### PR DESCRIPTION
The subhook URL has changed.  Redirect edkrepo to the new location. Thanks to HPE for the suggestion.

Ref: https://github.com/NVIDIA/edk2-nvidia/issues/109