### PR TITLE
chore: Update manifest to add uefi-202405.2 (r36.4.3)

### DIFF
--- a/edk2-nvidia/Platform/NVIDIAPlatformsManifest.xml
+++ b/edk2-nvidia/Platform/NVIDIAPlatformsManifest.xml
@@ -218,6 +218,24 @@
       <Source localRoot="edk2-nvidia-non-osi" remote="Edk2NvidiaNonOsiRepo" branch="r36.4.0-updates"/>
       <Source localRoot="edk2-nvidia-server-gpu-sdk/open-gpu-kernel-modules" remote="OpenRmRepo" tag="525.78.01"/>
     </Combination>
+    <Combination name="r36.4.3" description="The r36.4.3 release">
+      <Source localRoot="edk2" remote="Edk2Repo" tag="r36.4.3" enableSubmodule="true" />
+      <Source localRoot="edk2-non-osi" remote="Edk2NonOsiRepo" tag="r36.4.3"/>
+      <Source localRoot="edk2-platforms" remote="Edk2PlatformsRepo" tag="r36.4.3" sparseCheckout="true" />
+      <Source localRoot="edk2-redfish-client" remote="Edk2RedfishClientRepo" tag="r36.4.3"/>
+      <Source localRoot="edk2-nvidia" remote="Edk2NvidiaRepo" tag="r36.4.3"/>
+      <Source localRoot="edk2-nvidia-non-osi" remote="Edk2NvidiaNonOsiRepo" tag="r36.4.3"/>
+      <Source localRoot="edk2-nvidia-server-gpu-sdk/open-gpu-kernel-modules" remote="OpenRmRepo" tag="525.78.01"/>
+    </Combination>
+    <Combination name="r36.4.3-updates" description="The r36.4.3 release, plus updates">
+      <Source localRoot="edk2" remote="Edk2Repo" branch="r36.4.3-updates" enableSubmodule="true" />
+      <Source localRoot="edk2-non-osi" remote="Edk2NonOsiRepo" branch="r36.4.3-updates"/>
+      <Source localRoot="edk2-platforms" remote="Edk2PlatformsRepo" branch="r36.4.3-updates" sparseCheckout="true" />
+      <Source localRoot="edk2-redfish-client" remote="Edk2RedfishClientRepo" branch="r36.4.3-updates"/>
+      <Source localRoot="edk2-nvidia" remote="Edk2NvidiaRepo" branch="r36.4.3-updates"/>
+      <Source localRoot="edk2-nvidia-non-osi" remote="Edk2NvidiaNonOsiRepo" branch="r36.4.3-updates"/>
+      <Source localRoot="edk2-nvidia-server-gpu-sdk/open-gpu-kernel-modules" remote="OpenRmRepo" tag="525.78.01"/>
+    </Combination>
 
     <!-- uefi-202210, stable202210 -->
     <Combination name="stable202210" description="The uefi-202210 stable codeline">
@@ -555,6 +573,15 @@
       <Source localRoot="edk2-redfish-client" remote="Edk2RedfishClientRepo" tag="uefi-202405.1"/>
       <Source localRoot="edk2-nvidia" remote="Edk2NvidiaRepo" tag="uefi-202405.1"/>
       <Source localRoot="edk2-nvidia-non-osi" remote="Edk2NvidiaNonOsiRepo" tag="uefi-202405.1"/>
+      <Source localRoot="edk2-nvidia-server-gpu-sdk/open-gpu-kernel-modules" remote="OpenRmRepo" tag="525.78.01"/>
+    </Combination>
+    <Combination name="uefi-202405.2" description="The uefi-202405.2 release">
+      <Source localRoot="edk2" remote="Edk2Repo" tag="uefi-202405.2" enableSubmodule="true" />
+      <Source localRoot="edk2-non-osi" remote="Edk2NonOsiRepo" tag="uefi-202405.2"/>
+      <Source localRoot="edk2-platforms" remote="Edk2PlatformsRepo" tag="uefi-202405.2" sparseCheckout="true" />
+      <Source localRoot="edk2-redfish-client" remote="Edk2RedfishClientRepo" tag="uefi-202405.2"/>
+      <Source localRoot="edk2-nvidia" remote="Edk2NvidiaRepo" tag="uefi-202405.2"/>
+      <Source localRoot="edk2-nvidia-non-osi" remote="Edk2NvidiaNonOsiRepo" tag="uefi-202405.2"/>
       <Source localRoot="edk2-nvidia-server-gpu-sdk/open-gpu-kernel-modules" remote="OpenRmRepo" tag="525.78.01"/>
     </Combination>
 


### PR DESCRIPTION
The uefi-202405.2 release was used in Jetson Linux r36.4.3.