### PR TITLE
chore: add uefi-202504.3 + r36.5.1 combinations

### DIFF
--- a/edk2-nvidia/Platform/NVIDIAPlatformsManifest.xml
+++ b/edk2-nvidia/Platform/NVIDIAPlatformsManifest.xml
@@ -370,6 +370,24 @@
       <Source localRoot="edk2-nvidia" remote="Edk2NvidiaRepo" branch="r36.5-updates"/>
       <Source localRoot="edk2-nvidia-non-osi" remote="Edk2NvidiaNonOsiRepo" branch="r36.5-updates"/>
     </Combination>
+    <Combination name="r36.5.1" description="The r36.5.1 release">
+      <Source localRoot="edk2" remote="Edk2Repo" tag="r36.5.1" enableSubmodule="true" />
+      <Source localRoot="edk2-non-osi" remote="Edk2NonOsiRepo" tag="r36.5.1"/>
+      <Source localRoot="edk2-platforms" remote="Edk2PlatformsRepo" tag="r36.5.1" sparseCheckout="true" />
+      <Source localRoot="edk2-infineon" remote="Edk2InfineonRepo" tag="r36.5.1"/>
+      <Source localRoot="edk2-redfish-client" remote="Edk2RedfishClientRepo" tag="r36.5.1"/>
+      <Source localRoot="edk2-nvidia" remote="Edk2NvidiaRepo" tag="r36.5.1"/>
+      <Source localRoot="edk2-nvidia-non-osi" remote="Edk2NvidiaNonOsiRepo" tag="r36.5.1"/>
+    </Combination>
+    <Combination name="r36.5.1-updates" description="The r36.5.1 release, plus updates">
+      <Source localRoot="edk2" remote="Edk2Repo" branch="r36.5.1-updates" enableSubmodule="true" />
+      <Source localRoot="edk2-non-osi" remote="Edk2NonOsiRepo" branch="r36.5.1-updates"/>
+      <Source localRoot="edk2-platforms" remote="Edk2PlatformsRepo" branch="r36.5.1-updates" sparseCheckout="true" />
+      <Source localRoot="edk2-infineon" remote="Edk2InfineonRepo" branch="r36.5.1-updates"/>
+      <Source localRoot="edk2-redfish-client" remote="Edk2RedfishClientRepo" branch="r36.5.1-updates"/>
+      <Source localRoot="edk2-nvidia" remote="Edk2NvidiaRepo" branch="r36.5.1-updates"/>
+      <Source localRoot="edk2-nvidia-non-osi" remote="Edk2NvidiaNonOsiRepo" branch="r36.5.1-updates"/>
+    </Combination>
 
     <!-- rel-38 -->
     <Combination name="r38.2" description="The r38.2 release">
@@ -1184,6 +1202,16 @@
       <Source localRoot="edk2-redfish-client" remote="Edk2RedfishClientRepo" branch="uefi-202504.2-updates"/>
       <Source localRoot="edk2-nvidia" remote="Edk2NvidiaRepo" branch="uefi-202504.2-updates"/>
       <Source localRoot="edk2-nvidia-non-osi" remote="Edk2NvidiaNonOsiRepo" branch="uefi-202504.2-updates"/>
+      <Source localRoot="edk2-nvidia/Silicon/NVIDIA/Library/AvbLib/libavb" remote="AvbRepo" tag="android-platform-14.0.0_r5"/>
+    </Combination>
+    <Combination name="uefi-202504.3" description="The uefi-202504.3 release">
+      <Source localRoot="edk2" remote="Edk2Repo" tag="uefi-202504.3" enableSubmodule="true" />
+      <Source localRoot="edk2-non-osi" remote="Edk2NonOsiRepo" tag="uefi-202504.3"/>
+      <Source localRoot="edk2-platforms" remote="Edk2PlatformsRepo" tag="uefi-202504.3" sparseCheckout="true" />
+      <Source localRoot="edk2-infineon" remote="Edk2InfineonRepo" tag="uefi-202504.3"/>
+      <Source localRoot="edk2-redfish-client" remote="Edk2RedfishClientRepo" tag="uefi-202504.3"/>
+      <Source localRoot="edk2-nvidia" remote="Edk2NvidiaRepo" tag="uefi-202504.3"/>
+      <Source localRoot="edk2-nvidia-non-osi" remote="Edk2NvidiaNonOsiRepo" tag="uefi-202504.3"/>
       <Source localRoot="edk2-nvidia/Silicon/NVIDIA/Library/AvbLib/libavb" remote="AvbRepo" tag="android-platform-14.0.0_r5"/>
     </Combination>
 


### PR DESCRIPTION
Adds combinations for the uefi-202504.3 release and its r36.5.1 alias:
- `uefi-202504.3` tag combo (stable202504 section)
- `r36.5.1` tag combo (rel-36 section)
- `r36.5.1-updates` branch combo (rel-36 section)