### PR TITLE
chore: add uefi-202603.2 + r39.2 combinations

### DIFF
--- a/edk2-nvidia/Platform/NVIDIAPlatformsManifest.xml
+++ b/edk2-nvidia/Platform/NVIDIAPlatformsManifest.xml
@@ -63,6 +63,16 @@
     </Combination>
 
     <!-- uefi-202603 -->
+    <Combination name="stable202603" description="The uefi-202603 stable codeline">
+      <Source localRoot="edk2" remote="Edk2Repo" branch="stable202603" enableSubmodule="true" />
+      <Source localRoot="edk2-non-osi" remote="Edk2NonOsiRepo" branch="stable202603"/>
+      <Source localRoot="edk2-platforms" remote="Edk2PlatformsRepo" branch="stable202603" sparseCheckout="true" />
+      <Source localRoot="edk2-infineon" remote="Edk2InfineonRepo" branch="stable202603"/>
+      <Source localRoot="edk2-redfish-client" remote="Edk2RedfishClientRepo" branch="stable202603"/>
+      <Source localRoot="edk2-nvidia" remote="Edk2NvidiaRepo" branch="stable202603"/>
+      <Source localRoot="edk2-nvidia-non-osi" remote="Edk2NvidiaNonOsiRepo" branch="stable202603"/>
+      <Source localRoot="edk2-nvidia/Silicon/NVIDIA/Library/AvbLib/libavb" remote="AvbRepo" tag="android-platform-14.0.0_r5"/>
+    </Combination>
     <Combination name="uefi-202603.0" description="The uefi-202603.0 pre-release">
       <Source localRoot="edk2" remote="Edk2Repo" tag="uefi-202603.0" enableSubmodule="true" />
       <Source localRoot="edk2-non-osi" remote="Edk2NonOsiRepo" tag="uefi-202603.0"/>
@@ -101,6 +111,16 @@
       <Source localRoot="edk2-redfish-client" remote="Edk2RedfishClientRepo" branch="uefi-202603.1-updates"/>
       <Source localRoot="edk2-nvidia" remote="Edk2NvidiaRepo" branch="uefi-202603.1-updates"/>
       <Source localRoot="edk2-nvidia-non-osi" remote="Edk2NvidiaNonOsiRepo" branch="uefi-202603.1-updates"/>
+      <Source localRoot="edk2-nvidia/Silicon/NVIDIA/Library/AvbLib/libavb" remote="AvbRepo" tag="android-platform-14.0.0_r5"/>
+    </Combination>
+    <Combination name="uefi-202603.2" description="The uefi-202603.2 release">
+      <Source localRoot="edk2" remote="Edk2Repo" tag="uefi-202603.2" enableSubmodule="true" />
+      <Source localRoot="edk2-non-osi" remote="Edk2NonOsiRepo" tag="uefi-202603.2"/>
+      <Source localRoot="edk2-platforms" remote="Edk2PlatformsRepo" tag="uefi-202603.2" sparseCheckout="true" />
+      <Source localRoot="edk2-infineon" remote="Edk2InfineonRepo" tag="uefi-202603.2"/>
+      <Source localRoot="edk2-redfish-client" remote="Edk2RedfishClientRepo" tag="uefi-202603.2"/>
+      <Source localRoot="edk2-nvidia" remote="Edk2NvidiaRepo" tag="uefi-202603.2"/>
+      <Source localRoot="edk2-nvidia-non-osi" remote="Edk2NvidiaNonOsiRepo" tag="uefi-202603.2"/>
       <Source localRoot="edk2-nvidia/Silicon/NVIDIA/Library/AvbLib/libavb" remote="AvbRepo" tag="android-platform-14.0.0_r5"/>
     </Combination>
 
@@ -491,6 +511,26 @@
       <Source localRoot="edk2-nvidia" remote="Edk2NvidiaRepo" branch="r38.5-updates"/>
       <Source localRoot="edk2-nvidia-non-osi" remote="Edk2NvidiaNonOsiRepo" branch="r38.5-updates"/>
       <Source localRoot="edk2-nvidia/Silicon/NVIDIA/Library/AvbLib/libavb" remote="AvbRepo" tag="android-platform-14.0.0_r5"/>
+    </Combination>
+
+    <!-- rel-39 -->
+    <Combination name="r39.2" description="The r39.2 release">
+      <Source localRoot="edk2" remote="Edk2Repo" tag="r39.2" enableSubmodule="true" />
+      <Source localRoot="edk2-non-osi" remote="Edk2NonOsiRepo" tag="r39.2"/>
+      <Source localRoot="edk2-platforms" remote="Edk2PlatformsRepo" tag="r39.2" sparseCheckout="true" />
+      <Source localRoot="edk2-infineon" remote="Edk2InfineonRepo" tag="r39.2"/>
+      <Source localRoot="edk2-redfish-client" remote="Edk2RedfishClientRepo" tag="r39.2"/>
+      <Source localRoot="edk2-nvidia" remote="Edk2NvidiaRepo" tag="r39.2"/>
+      <Source localRoot="edk2-nvidia-non-osi" remote="Edk2NvidiaNonOsiRepo" tag="r39.2"/>
+    </Combination>
+    <Combination name="r39.2-updates" description="The r39.2 release, plus updates">
+      <Source localRoot="edk2" remote="Edk2Repo" branch="r39.2-updates" enableSubmodule="true" />
+      <Source localRoot="edk2-non-osi" remote="Edk2NonOsiRepo" branch="r39.2-updates"/>
+      <Source localRoot="edk2-platforms" remote="Edk2PlatformsRepo" branch="r39.2-updates" sparseCheckout="true" />
+      <Source localRoot="edk2-infineon" remote="Edk2InfineonRepo" branch="r39.2-updates"/>
+      <Source localRoot="edk2-redfish-client" remote="Edk2RedfishClientRepo" branch="r39.2-updates"/>
+      <Source localRoot="edk2-nvidia" remote="Edk2NvidiaRepo" branch="r39.2-updates"/>
+      <Source localRoot="edk2-nvidia-non-osi" remote="Edk2NvidiaNonOsiRepo" branch="r39.2-updates"/>
     </Combination>
 
     <!-- uefi-202210, stable202210 -->


### PR DESCRIPTION
Adds combinations for the uefi-202603.2 release and its r39.2 alias:
- `stable202603` branch combo (uefi-202603 section)
- `uefi-202603.2` tag combo (uefi-202603 section)
- `r39.2` tag combo (rel-39 section)
- `r39.2-updates` branch combo (rel-39 section)